### PR TITLE
Ignore within testing Cleanup calls 

### DIFF
--- a/testdata/src/contextbackground/basic/basic_test.go
+++ b/testdata/src/contextbackground/basic/basic_test.go
@@ -206,6 +206,12 @@ func Test_SwitchStmt_Tag(t *testing.T) {
 	}
 }
 
+func Test_IgnoreCleanup(t *testing.T) {
+	t.Cleanup(func() {
+		context.Background()
+	})
+}
+
 func foobar() {
 	context.Background()
 }

--- a/testdata/src/contextbackground/basic/basic_test.go.golden
+++ b/testdata/src/contextbackground/basic/basic_test.go.golden
@@ -206,6 +206,12 @@ func Test_SwitchStmt_Tag(t *testing.T) {
 	}
 }
 
+func Test_IgnoreCleanup(t *testing.T) {
+	t.Cleanup(func() {
+		context.Background()
+	})
+}
+
 func foobar() {
 	context.Background()
 }

--- a/testdata/src/contexttodo/basic/basic_test.go
+++ b/testdata/src/contexttodo/basic/basic_test.go
@@ -206,6 +206,8 @@ func Test_SwitchStmt_Tag(t *testing.T) {
 	}
 }
 
-func foobar() {
-	context.TODO()
+func Test_IgnoreCleanup(t *testing.T) {
+	t.Cleanup(func() {
+		context.TODO()
+	})
 }

--- a/testdata/src/contexttodo/basic/basic_test.go.golden
+++ b/testdata/src/contexttodo/basic/basic_test.go.golden
@@ -206,6 +206,8 @@ func Test_SwitchStmt_Tag(t *testing.T) {
 	}
 }
 
-func foobar() {
-	context.TODO()
+func Test_IgnoreCleanup(t *testing.T) {
+	t.Cleanup(func() {
+		context.TODO()
+	})
 }

--- a/usetesting.go
+++ b/usetesting.go
@@ -103,7 +103,6 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 	nodeFilter := []ast.Node{
 		(*ast.FuncDecl)(nil),
 		(*ast.FuncLit)(nil),
-		(*ast.CallExpr)(nil),
 	}
 
 	insp.WithStack(nodeFilter, func(node ast.Node, push bool, stack []ast.Node) (proceed bool) {
@@ -114,17 +113,6 @@ func (a *analyzer) run(pass *analysis.Pass) (any, error) {
 		switch fn := node.(type) {
 		case *ast.FuncDecl:
 			a.checkFunc(pass, fn.Type, fn.Body, fn.Name.Name)
-		case *ast.CallExpr:
-			sel, ok := fn.Fun.(*ast.SelectorExpr)
-			if !ok {
-				return true
-			}
-
-			if sel.Sel.Name == "Cleanup" {
-				if fn.Fun.(*ast.SelectorExpr).X.(*ast.Ident).Obj.Decl.(*ast.Field).Type.(*ast.StarExpr).X.(*ast.SelectorExpr).X.(*ast.Ident).Name == "testing" {
-					return false
-				}
-			}
 		case *ast.FuncLit:
 			if hasParentFunc(stack) {
 				return true


### PR DESCRIPTION
### What does this PR do?

Ignores the requirement of using `t.Context()` when the call is within t.Cleanup() calls. 

### Motivation

The context is cancelled already within t.Cleanup(). 

See Issue https://github.com/ldez/usetesting/issues/4 

Ive not handled this case yet. 🤔 
```go
func TestCleanup(t *testing.T) {
	ctx := context.Background()
	t.Cleanup(func() {
		t.Log(ctx.Err())
	})
}
```

### Additional Notes

There might be a better way of finding the testing import?  