### PR TITLE
Don't suggest test context in test cleanup functions

### DIFF
--- a/usetesting.go
+++ b/usetesting.go
@@ -146,6 +146,15 @@ func (a *analyzer) checkFunc(pass *analysis.Pass, ft *ast.FuncType, block *ast.B
 			return !a.reportIdent(pass, v, fnInfo, geGo124)
 
 		case *ast.CallExpr:
+			// Don't check inside t.Cleanup() calls
+			if selx, ok := v.Fun.(*ast.SelectorExpr); ok {
+				if idt, ok := selx.X.(*ast.Ident); ok {
+					if selx.Sel.Name == "Cleanup" && idt.Name == fnInfo.ArgName {
+						return false
+					}
+				}
+			}
+
 			return !a.reportCallExpr(pass, v, fnInfo)
 		}
 


### PR DESCRIPTION
Fixes https://github.com/ldez/usetesting/issues/4.

### What does this PR do?

Suggesting the replacement of `t.Context()` for `context.Background()` inside a test's `t.Cleanup()` functions is usually not a good suggestion since inside t.Cleanup functions the test context will already be cancelled so doing meaningful cleanup that uses context for timeout is not possible.

This PR detects the use of `t.Cleanup` and prunes further inspection of the child-nodes (i.e. the cleanup function literal).

### Motivation

I'd like to enable the `usetesting` linter in codebases I maintain but we make wide use of `t.Cleanup` with timeout contexts to close resources after a test ends in a limited amount of time (see the example in the added test case). Following this linter's suggestions causes such tests to fail because no time is allowed to clean up the resources (as the context returned by `t.Context()` is closed before cleanup functions are invoked)

### Additional Notes

Note that this fix cancels _all_ checking within `t.Cleanup` functions, not just for `context.Background/context.Todo`. Ideally within `t.Cleanup` functions we would still check for the other things this linter looks at, but I wasn't able to see a good way to do that given the structure of the linter.