### PR TITLE
fix: disable context-related checks by default

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,13 +40,13 @@ linters:
     
         # Enable/disable `context.Background()` detections.
         # Disabled if Go < 1.24.
-        # Default: true
-        context-background: false
+        # Default: false
+        context-background: true
     
         # Enable/disable `context.TODO()` detections.
         # Disabled if Go < 1.24.
-        # Default: true
-        context-todo: false
+        # Default: false
+        context-todo: true
 ```
 
 ### As a CLI

--- a/usetesting.go
+++ b/usetesting.go
@@ -76,8 +76,8 @@ func NewAnalyzer() *analysis.Analyzer {
 		Run:      l.run,
 	}
 
-	a.Flags.BoolVar(&l.contextBackground, "contextbackground", true, "Enable/disable context.Background() detections")
-	a.Flags.BoolVar(&l.contextTodo, "contexttodo", true, "Enable/disable context.TODO() detections")
+	a.Flags.BoolVar(&l.contextBackground, "contextbackground", false, "Enable/disable context.Background() detections")
+	a.Flags.BoolVar(&l.contextTodo, "contexttodo", false, "Enable/disable context.TODO() detections")
 	a.Flags.BoolVar(&l.osChdir, "oschdir", true, "Enable/disable os.Chdir() detections")
 	a.Flags.BoolVar(&l.osMkdirTemp, "osmkdirtemp", true, "Enable/disable os.MkdirTemp() detections")
 	a.Flags.BoolVar(&l.osSetenv, "ossetenv", false, "Enable/disable os.Setenv() detections")

--- a/usetesting_test.go
+++ b/usetesting_test.go
@@ -16,15 +16,15 @@ func TestAnalyzer(t *testing.T) {
 		{dir: "oschdir/nottestfiles"},
 		{dir: "oschdir/disable", options: map[string]string{"oschdir": "false"}},
 
-		{dir: "contextbackground/basic"},
-		{dir: "contextbackground/dot"},
-		{dir: "contextbackground/nottestfiles"},
-		{dir: "contextbackground/disable", options: map[string]string{"contextbackground": "false"}},
+		{dir: "contextbackground/basic", options: map[string]string{"contextbackground": "true"}},
+		{dir: "contextbackground/dot", options: map[string]string{"contextbackground": "true"}},
+		{dir: "contextbackground/nottestfiles", options: map[string]string{"contextbackground": "true"}},
+		{dir: "contextbackground/disable"},
 
-		{dir: "contexttodo/basic"},
-		{dir: "contexttodo/dot"},
-		{dir: "contexttodo/nottestfiles"},
-		{dir: "contexttodo/disable", options: map[string]string{"contexttodo": "false"}},
+		{dir: "contexttodo/basic", options: map[string]string{"contexttodo": "true"}},
+		{dir: "contexttodo/dot", options: map[string]string{"contexttodo": "true"}},
+		{dir: "contexttodo/nottestfiles", options: map[string]string{"contexttodo": "true"}},
+		{dir: "contexttodo/disable"},
 
 		{dir: "osmkdirtemp/basic"},
 		{dir: "osmkdirtemp/dot"},


### PR DESCRIPTION
### What does this PR do?

Disables context-related checks by default.

The main problem is related to #9.

It's more ambiguous about #10 because IMO using `t.context` in test files is the right approach by default.
A fine granularity of options and a rewrite of the linter are the proper ways to handle those situations. For now, this PR will only reduce the problem.

### Motivation

Fixes #10 

### Additional Notes

Related #9 

